### PR TITLE
Update DOS Network Token Address in BAL whitelist

### DIFF
--- a/src/config/homestead.json
+++ b/src/config/homestead.json
@@ -1984,8 +1984,8 @@
       "color": "#9a9a97",
       "hasIcon": true
     },
-    "0x70861e862E1Ac0C96f853C8231826e469eAd37B1": {
-      "address": "0x70861e862E1Ac0C96f853C8231826e469eAd37B1",
+    "0x0A913beaD80F321E7Ac35285Ee10d9d922659cB7": {
+      "address": "0x0A913beaD80F321E7Ac35285Ee10d9d922659cB7",
       "id": "dos-network",
       "name": "DOS Network Token",
       "symbol": "DOS",


### PR DESCRIPTION
Hello Balancer Friends,

DOS token contract has been upgraded from https://etherscan.io/address/0x70861e862e1ac0c96f853c8231826e469ead37b1 [obsoleted one] to https://etherscan.io/address/0x0A913beaD80F321E7Ac35285Ee10d9d922659cB7 [new one].

Announcement thread [here](https://twitter.com/DOSNetwork/status/1286571589371179008), also we've got this verified and updated on Etherscan, Coingecko, and CoinMarketCap.

Please kindly help our team to merge this pull request and we're planning to launch liquidity incentives on Balancer and Uniswap.

Thanks!
