### PR TITLE
Support "Unlimited" when editing BSP cap

### DIFF
--- a/src/_balancer/pool.ts
+++ b/src/_balancer/pool.ts
@@ -68,7 +68,8 @@ export default class Pool {
         symbol,
         totalShares,
         rights,
-        bspCap
+        bspCap,
+        crpController
       ] = await multicall(
         provider,
         abi['ConfigurableRightsPool'],
@@ -79,7 +80,8 @@ export default class Pool {
           'symbol',
           'totalSupply',
           'rights',
-          'bspCap'
+          'bspCap',
+          'getController'
         ].map(method => [address, method, []])
       );
       return {
@@ -90,7 +92,8 @@ export default class Pool {
         rights: Object.fromEntries(
           Object.entries(poolRights).map((right, i) => [right[0], rights[i]])
         ),
-        bspCap: formatUnits(bspCap.toString(), decimals)
+        bspCap: formatUnits(bspCap.toString(), decimals),
+        crpController: crpController[0]
       };
     }
     const [

--- a/src/components/Modal/Account.vue
+++ b/src/components/Modal/Account.vue
@@ -28,7 +28,7 @@
       <h3 v-text="$t('account')" class="p-4 border-bottom text-center" />
       <div v-if="web3.account" class="m-4">
         <a
-          :href="_etherscanLink(web3.account)"
+          :href="_etherscanLink(web3.account, 'address')"
           target="_blank"
           class="mb-2 d-block"
         >

--- a/src/components/Modal/Account.vue
+++ b/src/components/Modal/Account.vue
@@ -28,7 +28,7 @@
       <h3 v-text="$t('account')" class="p-4 border-bottom text-center" />
       <div v-if="web3.account" class="m-4">
         <a
-          :href="_etherscanLink(web3.account, 'address')"
+          :href="_etherscanLink(web3.account)"
           target="_blank"
           class="mb-2 d-block"
         >

--- a/src/components/Modal/EditCap.vue
+++ b/src/components/Modal/EditCap.vue
@@ -8,6 +8,14 @@
         <h5 class="px-4 mb-4 mx-auto overflow-hidden" style="max-width: 340px;">
           {{ $t('changePoolSupplyCap') }}
         </h5>
+        <div class="text-center m-4 mt-0">
+          <Toggle
+            :value="type"
+            :options="capInputOptions"
+            @select="handleSelectType"
+            class="mt-4"
+          />
+        </div>
         <input
           type="number"
           class="h3 py-2 px-3 input text-center"
@@ -15,6 +23,7 @@
           :class="isValid ? 'text-white' : 'text-red'"
           :min="0"
           :step="1"
+          :disabled="'UNLIMITED' == this.type"
           v-model="input"
         />
       </div>
@@ -23,7 +32,7 @@
           {{ $t('cancel') }}
         </UiButton>
         <UiButton
-          :disabled="loading || input === value"
+          :disabled="loading || (input === value && 'NUMERIC' == type)"
           :loading="loading"
           type="submit"
           class="button-primary mx-1"
@@ -38,19 +47,24 @@
 <script>
 import { mapActions } from 'vuex';
 import { validateNumberInput, ValidationError } from '@/helpers/validation';
+import { MAX, capInputOptions } from '@/helpers/utils';
 
 export default {
   props: ['open', 'value', 'pool'],
   data() {
     return {
       loading: false,
-      input: false
+      input: false,
+      type: false,
+      capInputOptions,
+      MAX
     };
   },
   watch: {
     open() {
       this.loading = false;
-      this.input = this.value.replace('.0', '');
+      this.input = this.value === MAX ? '' : this.value.replace('.0', '');
+      this.type = this.value === MAX ? 'UNLIMITED' : 'NUMERIC';
     }
   },
   computed: {
@@ -69,13 +83,16 @@ export default {
       try {
         this.tx = await this.setCap({
           poolAddress: this.pool.controller,
-          newCap: this.input
+          newCap: 'UNLIMITED' == this.type ? MAX.toString() : this.input
         });
         this.$emit('close');
       } catch (e) {
         console.error(e);
       }
       this.loading = false;
+    },
+    handleSelectType(type) {
+      this.type = type;
     }
   }
 };

--- a/src/components/Modal/EditCap.vue
+++ b/src/components/Modal/EditCap.vue
@@ -56,8 +56,7 @@ export default {
       loading: false,
       input: false,
       type: false,
-      capInputOptions,
-      MAX
+      capInputOptions
     };
   },
   watch: {

--- a/src/components/Modal/EditController.vue
+++ b/src/components/Modal/EditController.vue
@@ -8,6 +8,10 @@
         <h5 class="px-4 mb-4 mx-auto overflow-hidden" style="max-width: 340px;">
           {{ $t('changePoolController') }}
         </h5>
+        <div class="d-flex flex-items-center p-4 warning-box">
+          <Icon name="warning" size="22" class="mr-4" />
+          {{ $t('changeControllerWarning') }}
+        </div>
         <input
           class="h3 py-2 px-3 input text-center"
           :class="isValid ? 'text-white' : 'text-red'"
@@ -72,3 +76,13 @@ export default {
   }
 };
 </script>
+
+<style scoped lang="scss">
+@import '../../vars';
+
+.warning-box {
+  border: 1px solid $warning;
+  border-radius: 4px;
+  color: $warning;
+}
+</style>

--- a/src/components/PoolHeader.vue
+++ b/src/components/PoolHeader.vue
@@ -26,7 +26,7 @@
         </span>
         <UiLabel v-if="!pool.metadata.finalized" v-text="pool.getTypeStr()" />
       </h3>
-      <a :href="_etherscanLink(pool.getBptAddress())" target="_blank">
+      <a :href="_etherscanLink(pool.getBptAddress(), 'token')" target="_blank">
         <span
           v-if="pool.config.symbol || pool.metadata.symbol"
           v-text="_shorten(pool.config.symbol || pool.metadata.symbol)"

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -34,7 +34,8 @@ export default {
       });
       if (
         this.web3.account &&
-        this.web3.dsProxyAddress.toLowerCase() === this.pool.crpController
+        this.web3.dsProxyAddress.toLowerCase() ===
+          this.pool.crpController.toLowerCase()
       ) {
         items.push({
           name: this.$t('settings'),

--- a/src/helpers/queries.json
+++ b/src/helpers/queries.json
@@ -35,7 +35,6 @@
       "controller": true,
       "finalized": true,
       "crp": true,
-      "crpController": true,
       "swapFee": true,
       "totalWeight": true,
       "totalSwapVolume": true,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -11,6 +11,8 @@ export const MAX_GAS = new BigNumber('0xffffffff');
 export const MAX_UINT = MaxUint256;
 export const POOL_TOKENS_DECIMALS = 18;
 export const GAS_LIMIT_BUFFER = 0.1;
+export const MAX =
+  '115792089237316195423570985008687907853269984665640564039457.584007913129639935';
 
 export const unknownColors = [
   '#5d6872',
@@ -22,6 +24,11 @@ export const unknownColors = [
   '#c7bdf4',
   '#c28d75'
 ];
+
+export const capInputOptions = {
+  NUMERIC: 'Value',
+  UNLIMITED: 'Unlimited'
+};
 
 export const liquidityToggleOptions = {
   MULTI_ASSET: 'Multi asset',

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -36,6 +36,7 @@
     "canChangeCap": "Can change pool cap",
     "cap": "Cap",
     "change": "Change",
+    "changeControllerWarning": "Ensure you have the private key to this address! Otherwise you will lose control of the pool!",
     "changePoolController": "Change pool controller",
     "changePoolSupplyCap": "Change pool supply cap",
     "confirm": "Confirm",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -159,6 +159,7 @@
     "tradeIn": "Trade in",
     "tradeOut": "Trade out",
     "transaction": "Transaction",
+    "unlimited": "Unlimited",
     "unlock": "unlock",
     "untrustedTokens": "This pool contains an untrusted token that may cause loss of funds. Do not deposit.",
     "unwrap": "Unwrap",

--- a/src/views/Pool/About.vue
+++ b/src/views/Pool/About.vue
@@ -29,7 +29,13 @@
     </div>
     <div v-if="rights.canChangeCap" class="mb-3">
       <div v-text="$t('cap')" class="mb-2" />
-      <h5 v-text="_num(bPool.metadata.bspCap)" class="text-white" />
+      <h5 class="text-white">
+        <div
+          v-if="bPool.metadata.bspCap.toString() === MAX"
+          v-text="$t('unlimited')"
+        />
+        <div v-else v-text="_num(bPool.metadata.bspCap)" />
+      </h5>
     </div>
     <div class="mb-3">
       <div
@@ -38,7 +44,7 @@
       />
       <h5>
         <a
-          :href="_etherscanLink(bPool.metadata.controller)"
+          :href="_etherscanLink(bPool.metadata.controller, 'token')"
           target="_blank"
           class="text-white"
         >
@@ -52,7 +58,7 @@
       <div v-text="$t('smartPoolController')" class="mb-2" />
       <h5>
         <a
-          :href="_etherscanLink(bPool.metadata.crpController)"
+          :href="_etherscanLink(bPool.metadata.crpController, 'address')"
           target="_blank"
           class="text-white"
         >
@@ -124,13 +130,14 @@
 </template>
 
 <script>
-import { filterObj, poolRights } from '@/helpers/utils';
+import { filterObj, poolRights, MAX } from '@/helpers/utils';
 
 export default {
   props: ['bPool'],
   data() {
     return {
-      poolRights
+      poolRights,
+      MAX
     };
   },
   computed: {

--- a/src/views/Pool/About.vue
+++ b/src/views/Pool/About.vue
@@ -58,7 +58,7 @@
       <div v-text="$t('smartPoolController')" class="mb-2" />
       <h5>
         <a
-          :href="_etherscanLink(bPool.metadata.crpController, 'address')"
+          :href="_etherscanLink(bPool.metadata.crpController)"
           target="_blank"
           class="text-white"
         >

--- a/src/views/Pool/Settings.vue
+++ b/src/views/Pool/Settings.vue
@@ -143,6 +143,6 @@ export default {
       },
       MAX
     };
-  },
+  }
 };
 </script>

--- a/src/views/Pool/Settings.vue
+++ b/src/views/Pool/Settings.vue
@@ -31,7 +31,10 @@
         <UiButton v-text="$t('change')" @click="modalOpen.cap = true" />
       </div>
       <label v-text="$t('cap')" class="d-block mb-2" />
-      <p v-text="_num(pool.bspCap)" class="text-gray" />
+      <div class="text-gray">
+        <div v-if="pool.bspCap === MAX" v-text="$t('unlimited')" />
+        <div v-else v-text="_num(pool.bspCap)" />
+      </div>
     </div>
     <div
       v-if="bPool.metadata.rights.canAddRemoveTokens && 1 === 2"
@@ -124,7 +127,7 @@
 
 <script>
 import { getAddress } from '@ethersproject/address';
-import { bnum, scale } from '@/helpers/utils';
+import { bnum, scale, MAX } from '@/helpers/utils';
 
 export default {
   props: ['pool', 'bPool'],
@@ -138,7 +141,8 @@ export default {
         weights: false,
         gradualWeights: false,
         tokens: false
-      }
+      },
+      MAX
     };
   },
   computed: {

--- a/src/views/Pool/Settings.vue
+++ b/src/views/Pool/Settings.vue
@@ -126,8 +126,7 @@
 </template>
 
 <script>
-import { getAddress } from '@ethersproject/address';
-import { bnum, scale, MAX } from '@/helpers/utils';
+import { MAX } from '@/helpers/utils';
 
 export default {
   props: ['pool', 'bPool'],
@@ -145,14 +144,5 @@ export default {
       MAX
     };
   },
-  computed: {
-    cap() {
-      const address = getAddress(this.pool.controller);
-      const crp = this.web3.crps[address];
-      if (!crp) return '0';
-      const capNumber = scale(bnum(crp.bspCap), -18);
-      return capNumber.toString();
-    }
-  }
 };
 </script>


### PR DESCRIPTION
Changes proposed in this pull request:
- Support "Unlimited" when editing BSP cap
- Ensure proper type on etherscanLink calls
- Read controller from contract vs graph, to support setController
