### PR TITLE
Clarify label on Remove liquidity

### DIFF
--- a/src/components/Modal/RemoveLiquidity.vue
+++ b/src/components/Modal/RemoveLiquidity.vue
@@ -23,7 +23,7 @@
             <UiTableTh>
               <div v-text="$t('asset')" class="column-lg flex-auto text-left" />
               <div v-text="$t('myPoolBalance')" class="column" />
-              <div v-text="$t('removeLiquidity')" class="column-sm" />
+              <div v-text="$t('withdrawalAmt')" class="column-sm" />
             </UiTableTh>
             <UiTableTr
               v-for="token in tokens"

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -239,6 +239,7 @@
     "weightsPct": "Weights percent",
     "willBurn": "This operation will burn",
     "withdraw": "Withdraw",
+    "withdrawalAmt": "Withdrawal amt",
     "wrap": "Wrap",
     "wrapEthToWeth": "Change ETH to wETH",
     "wrapFactor": "Wrap factor",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -239,7 +239,7 @@
     "weightsPct": "Weights percent",
     "willBurn": "This operation will burn",
     "withdraw": "Withdraw",
-    "withdrawalAmt": "Withdrawal amt",
+    "withdrawalAmt": "Withdrawal amt.",
     "wrap": "Wrap",
     "wrapEthToWeth": "Change ETH to wETH",
     "wrapFactor": "Wrap factor",


### PR DESCRIPTION
Changes proposed in this pull request:
- While explaining this modal, realized the 2nd column label is confusing/uninformative
- It's showing their balance - and how much will be withdrawn for the given # of pool tokens