### PR TITLE
Remove liquidity browser lockup

### DIFF
--- a/src/helpers/math.ts
+++ b/src/helpers/math.ts
@@ -67,8 +67,18 @@ function bpowApprox(
   let term = BONE;
   let sum = term;
   let negative = false;
+  const LOOP_LIMIT = 1000;
 
+  let idx = 0;
   for (let i = 1; term.gte(precision); i++) {
+    idx +=1;
+    // Some values cause it to lock up the browser
+    // These seem to be cases where it's going to be invalid anyway
+    // So halt after a max iteration limit
+    if (LOOP_LIMIT == idx) {
+      break
+    }
+
     const bigK = new BigNumber(i).times(BONE);
     const { res: c, bool: cneg } = bsubSign(a, bigK.minus(BONE));
     term = bmul(term, bmul(c, x));

--- a/src/helpers/math.ts
+++ b/src/helpers/math.ts
@@ -71,13 +71,13 @@ function bpowApprox(
 
   let idx = 0;
   for (let i = 1; term.gte(precision); i++) {
-    idx +=1;
+    idx += 1;
     // Some values cause it to lock up the browser
     // Test case: Remove Liquidity, single asset, poolAmountIn >> max
     // These seem to be cases where it's going to be invalid anyway
     // So halt after a max iteration limit
     if (LOOP_LIMIT == idx) {
-      break
+      break;
     }
 
     const bigK = new BigNumber(i).times(BONE);

--- a/src/helpers/math.ts
+++ b/src/helpers/math.ts
@@ -73,6 +73,7 @@ function bpowApprox(
   for (let i = 1; term.gte(precision); i++) {
     idx +=1;
     // Some values cause it to lock up the browser
+    // Test case: Remove Liquidity, single asset, poolAmountIn >> max
     // These seem to be cases where it's going to be invalid anyway
     // So halt after a max iteration limit
     if (LOOP_LIMIT == idx) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove Liquidity single asset with poolAmountIn >> max locks up browser
- Abort bpowApprox after a max iteration limit if it's not converging
