### PR TITLE
Always allow pokeWeights

### DIFF
--- a/src/views/Pool/Actions.vue
+++ b/src/views/Pool/Actions.vue
@@ -14,7 +14,6 @@
       />
       <p v-html="$t('pokeWeightsGeneral')" class="mb-3" v-else />
       <UiButton
-        :disabled="!ongoingUpdate"
         :loading="loading"
         @click="handlePokeWeights()"
       >


### PR DESCRIPTION
Changes proposed in this pull request:
- Always allow pokeWeights to be called
- Otherwise currentBlock outages prevent calling pokeWeights
