### PR TITLE
build: update caniuse-lite to fix warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4475,9 +4475,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001066",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001066.tgz",
-      "integrity": "sha512-Gfj/WAastBtfxLws0RCh2sDbTK/8rJuSeZMecrSkNGYxPcv7EzblmDGfWQCFEQcSqYE2BRgQiJh8HOD07N5hIw=="
+      "version": "1.0.30001161",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz",
+      "integrity": "sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",


### PR DESCRIPTION
Simple PR. I was getting warnings about caniuse-lite being out of date so I ran the suggested command `npx browserslist@latest --update-db`.