### PR TITLE
fix: avoid reading nonexistent metadata property from this.pool

### DIFF
--- a/src/components/Modal/EditWeights.vue
+++ b/src/components/Modal/EditWeights.vue
@@ -112,7 +112,7 @@ export default {
           toWei(totalWeight),
           toWei(token.denormWeight).times(2),
           toWei(this.weights[this.tokenIndex]),
-          bnum(this.pool.metadata.totalShares)
+          bnum(this.pool.totalShares)
         );
         return poolAmountIn.toString();
       }


### PR DESCRIPTION
In `EditWeights` you're trying to read `metadata.totalShares` off of the `this.pool` object while `this.pool == bPool.metadata` so we're in effect reading `bPool.metadata.metadata.totalShares`, resulting in trying to read `totalShares` property of undefined.

I've removed the redundant layer of `metadata` which was resulting in a failure to decrease a token's weight.