### PR TITLE
Remove leftover hard-coding of weights in broadcast.ts

### DIFF
--- a/src/store/modules/broadcast.ts
+++ b/src/store/modules/broadcast.ts
@@ -596,9 +596,7 @@ const actions = {
     commit('INCREASE_WEIGHT_REQUEST');
     const dsProxyAddress = rootState.web3.dsProxyAddress;
     try {
-      newWeight = toWei(newWeight)
-        .div(2)
-        .toString();
+      newWeight = toWei(newWeight).toString();
       const tokenMetadata = rootState.web3.tokenMetadata[token];
       const decimals = tokenMetadata ? tokenMetadata.decimals : null;
       tokenAmountIn = denormalizeBalance(tokenAmountIn, decimals)
@@ -627,9 +625,7 @@ const actions = {
     commit('DECREASE_WEIGHT_REQUEST');
     const dsProxyAddress = rootState.web3.dsProxyAddress;
     try {
-      newWeight = toWei(newWeight)
-        .div(2)
-        .toString();
+      newWeight = toWei(newWeight).toString();
       poolAmountIn = toWei(poolAmountIn);
       const underlyingParams = [
         'BActions',
@@ -655,9 +651,7 @@ const actions = {
     const dsProxyAddress = rootState.web3.dsProxyAddress;
     try {
       newWeights = tokens.map(token => {
-        return toWei(newWeights[token])
-          .div(2)
-          .toString();
+        return toWei(newWeights[token]).toString();
       });
       const underlyingParams = [
         'BActions',
@@ -708,9 +702,7 @@ const actions = {
       balance = denormalizeBalance(balance, decimals)
         .integerValue(BigNumber.ROUND_DOWN)
         .toString();
-      denormalizedWeight = toWei(denormalizedWeight)
-        .div(2)
-        .toString();
+      denormalizedWeight = toWei(denormalizedWeight).toString();
       const underlyingParams = [
         'BActions',
         config.addresses.bActions,


### PR DESCRIPTION
Changes proposed in this pull request:
- Absolute denorms are calculated already in the GUI
- Leftover code in broadcast was dividing by 2
- Worked accidentally most of the time, but not when denorms are 1/23/1