### PR TITLE
Do not show invalid block-dependent calculation results

### DIFF
--- a/src/components/Modal/EditWeightsGradually.vue
+++ b/src/components/Modal/EditWeightsGradually.vue
@@ -42,7 +42,10 @@
         </UiTableTr>
       </UiTable>
       <div class="m-4">
-        <div class="d-flex flex-items-center mb-2">
+        <div
+          v-if="this.web3.blockNumber > 0"
+          class="d-flex flex-items-center mb-2"
+        >
           <div v-text="$t('startBlock')" class="flex-auto" />
           <div class="column-sm">
             <input
@@ -78,7 +81,7 @@
           {{ $t('cancel') }}
         </UiButton>
         <UiButton
-          :disabled="loading || !isValid"
+          :disabled="loading || !isValid || this.web3.blockNumber == 0"
           :loading="loading"
           type="submit"
           class="button-primary mx-1"

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -145,6 +145,7 @@
     "of": "of",
     "ofSlippage": "of slippage",
     "ongoingUpdate": "There is a gradual weights update underway<br> from {startTime} ({startBlock})<br> until {endTime} ({endBlock})",
+    "ongoingUpdateLoading": "There is a gradual weights update underway... waiting for block information",
     "paused": "Paused",
     "pendingTransactions": "Pending transaction(s)",
     "percent": "Percent",

--- a/src/views/Pool/About.vue
+++ b/src/views/Pool/About.vue
@@ -35,7 +35,10 @@
       <h5 v-else v-text="$t('none')" class="text-white" />
     </div>
     <div v-if="ongoingUpdate" class="mb-3">
-      <div class="d-flex flex-items-center p-4 warning-box">
+      <div
+        v-if="this.web3.blockNumber > 0"
+        class="d-flex flex-items-center p-4 warning-box"
+      >
         <Icon name="warning" size="22" class="mr-4" />
         <div
           v-if="updateFinished"
@@ -52,6 +55,10 @@
             })
           "
         />
+      </div>
+      <div v-else class="d-flex flex-items-center p-4 warning-box">
+        <Icon name="warning" size="22" class="mr-4" />
+        <div v-text="$t('ongoingUpdateLoading')" />
       </div>
     </div>
     <div v-if="bPool.isCrp() && lbpData.isLbpPool">

--- a/src/views/Pool/Actions.vue
+++ b/src/views/Pool/Actions.vue
@@ -6,7 +6,12 @@
       style="max-width: 440px;"
     >
       <h5 v-text="$t('poke')" class="mb-3" />
-      <p v-html="$t('pokeWeightsEarly')" class="mb-3" v-if="tooEarly" />
+      <p
+        v-text="$t('ongoingUpdateLoading')"
+        class="mb-3"
+        v-if="this.web3.blockNumber == 0"
+      />
+      <p v-html="$t('pokeWeightsEarly')" class="mb-3" v-else-if="tooEarly" />
       <p
         v-html="$t('pokeWeightsOngoing')"
         class="mb-3"


### PR DESCRIPTION
Changes proposed in this pull request:
- Gradual weight updates show text calculated using the latest block
- When the page initially loads, it shows bogus information
- Wait until the first block arrives to display it; show a placeholder in the meantime