### PR TITLE
Fix displaying "Nan" lbpPrice for a dead pool

### DIFF
--- a/src/_balancer/pool.ts
+++ b/src/_balancer/pool.ts
@@ -40,6 +40,7 @@ export default class Pool {
     if (
       !this.metadata.liquidity ||
       !this.metadata.totalShares ||
+      this.metadata.totalShares == 0 ||
       (!this.metadata.finalized && !this.isCrp())
     )
       return 0;


### PR DESCRIPTION
Changes proposed in this pull request:
- Currently displays $NaN bptPrice for "dead" pool
- Need to check for 0 totalSupply 
