### PR TITLE
Remove multiplier for proper date display

### DIFF
--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -125,7 +125,7 @@ export default {
 
           if (i > 0 && swap.timestamp != this.swaps[i - 1].timestamp) {
             data.push({
-              time: swap.timestamp * 1e3,
+              time: swap.timestamp,
               value: swapPrice(this.pool, this.config.chainId, swap)
             });
           }


### PR DESCRIPTION
Changes proposed in this pull request:
- x-axis of price graph does not need 1e3 multiplier