### PR TITLE
Allow explicit navigation to Dashboard

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -36,7 +36,9 @@ export default {
     }
   },
   beforeMount() {
-    if (!this.web3.account) this.$router.push({ name: 'explore' });
+    if (!this.web3.account && !location.href.includes('dashboard')) {
+      this.$router.push({ name: 'explore' });
+    }
   }
 };
 </script>


### PR DESCRIPTION
Fixes #U-402 on V2

Changes proposed in this pull request:
- Keep default behavior of going to Explore back from root
- Unless the path is /dashboard
- This allows V2 to link directly to the dashboard
